### PR TITLE
Make main return type explicit

### DIFF
--- a/src/nsc.c
+++ b/src/nsc.c
@@ -889,7 +889,7 @@ int i;
      }
 }
 
-main(int argc,char **argv){
+int main(int argc,char **argv){
 
   int i;
   double area, volume;


### PR DESCRIPTION
Compiling with GCC 10 on macOS results in the following warning:
```
nsc.c:892:1: warning: return type defaults to 'int' [-Wimplicit-int]
  892 | main(int argc,char **argv){
      | ^~~~
```

This PR makes the return type of `main` explicit, so that the warning disappears.