### PR TITLE
Allow visualization of multiple point clouds

### DIFF
--- a/utils/visualize.py
+++ b/utils/visualize.py
@@ -1,17 +1,16 @@
-#!/usr/bin/python3.7
-
-#execute ./<>.py <pcd or xyzrgb file> - Display
-
 import open3d as o3d
-import os, sys
+import argparse
 
-# sys.argv[0] is the name of the program itself
-target=sys.argv[1]
-#source=sys.argv[2]
+p = argparse.ArgumentParser(description="Visualize point clouds with Open3D")
+p.add_argument("files", type=str, nargs="+", help="files")
 
-target_pcd = o3d.io.read_point_cloud(target)
-#source_pcd = o3d.io.read_point_cloud(source)
+args = p.parse_args()
 
-o3d.visualization.draw_geometries([target_pcd],window_name='open3d-molecule',width=1000, height=800, left=50, top=50)
-#to read 2 clouds
-#o3d.visualization.draw_geometries([target_pcd,source_pcd],window_name='open3d-molecule',width=1000, height=800, left=50, top=50)
+pcds = []
+for f in args.files:
+    pcd = o3d.io.read_point_cloud(f)
+    pcds.append(pcd)
+
+o3d.visualization.draw_geometries(
+    pcds, window_name="open3d-molecule", width=1000, height=800, left=50, top=50
+)


### PR DESCRIPTION
I noticed that `utils/visualize.py` contained commented code to visualize a second point cloud. I needed to visualize three point clouds (source, target, translated), therefore I generalized the script to work with any number of point clouds.

Please feel free to close this PR if it is not useful.